### PR TITLE
IssueFixes(17,18,19)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ofs-users/plugin",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ofs-users/plugin",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "UPL-1.0",
       "dependencies": {
         "@ofs-users/proxy": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "@ofs-users/plugin",
   "type": "module",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Oracle Field Service plugin base code",
   "main": "dist/ofs-plugin.es.js",
   "module": "dist/ofs-plugin.es.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,12 +71,19 @@ export abstract class OFSPlugin {
     private _proxy!: OFS;
     private _tag: string;
 
-    constructor(tag: string) {
+    /**
+     * 
+     * @param {string} tag Plugin Tag/Name
+     * @param {boolean} [initOverride = false] Defaults to false. When false, invokes the Setup method implicitly and sends the ready message to OFS Core immediatly. When set to true, allows the implementing plugin call the Setup function explicitly. This allows the implementing plugin to control when Plugin starts communication with OFS Core application.
+     */
+    constructor(tag: string, initOverride: boolean = false) {
         console.log(`${tag}: Created`);
 
         this._tag = tag;
-
-        //this._setup(); //Issue#17: Method converted to public and needs to be invoked explicitly by the implementing calss.
+        //For backward compatibility. When initOverride param is not provided in contructor, the setup mothod would be called automatically without requiring the plugins to make any changes in their implementation. 
+        if(!initOverride){
+            this.setup(); //Issue#17: Method converted to public and can be invoked explicitly by the implementing calss.
+        }
     }
 
     get proxy(): OFS {
@@ -269,10 +276,11 @@ export abstract class OFSPlugin {
         });
     }
 
-    //Issue#17: Converted to a public method allowing implementing plugin to pass additional parameters to OFS. 
-    //The Implementing plugin will need to call this method explicitly unlike before where it was auto called in constructor.
+    // Issue#17: Converted to a public method allowing implementing plugin to pass additional parameters to OFS. 
     /**
      * Setups event listeners and initiates the communication between Plugin & OFS by sending 'ready' message.
+     * The Implementing plugin can can call this method explicitly unlike before where it was auto called in constructor only. For that, 
+     * Plugin needs to pass an additional parameter to constructor 'initOverride' as true. otherwise, this function is auto called implicitly.
      * @param {boolean} sendInitData defaults to true
      * @param {boolean} enableBackButton defaults to true
      * @param {boolean} showHeader defaults to true
@@ -284,7 +292,7 @@ export abstract class OFSPlugin {
      * //Implement the OFS Plugin
      * class MyPlugin Extends OFSPlugin{
      *  constructor () {
-     *      super("myPlugin");
+     *      super("myPlugin", true);
      *  }
      * }
      * 
@@ -294,7 +302,7 @@ export abstract class OFSPlugin {
      * ```
      * For details see: https://docs.oracle.com/en/cloud/saas/field-service/fapcf/c-readymethod-new.html
      */
-    public Setup(sendInitData:boolean = true, enableBackButton:boolean = true, showHeader:boolean = true, sendMessageAsJsObject:boolean = false, dataItems?:Array<string>) {
+    public setup(sendInitData:boolean = true, enableBackButton:boolean = true, showHeader:boolean = true, sendMessageAsJsObject:boolean = false, dataItems?:Array<string>) {
         console.log("OFS plugin ready");
         window.addEventListener(
             "message",

--- a/src/main.ts
+++ b/src/main.ts
@@ -292,7 +292,7 @@ export abstract class OFSPlugin {
      * //Implement the OFS Plugin
      * class MyPlugin Extends OFSPlugin{
      *  constructor () {
-     *      super("myPlugin", true);
+     *      super("myPlugin", true); //set the 2nd paramter to true to override setup method call.
      *  }
      * }
      * 
@@ -312,7 +312,13 @@ export abstract class OFSPlugin {
         var messageData: OFSMessage = {
             apiVersion: 1,
             method: "ready",
-            sendInitData: true,
+            sendInitData: sendInitData,
+            enableBackButton: enableBackButton,
+            showHeader: showHeader,
+            sendMessageAsJsObject: sendMessageAsJsObject,
+        };
+        if(dataItems){
+            messageData.dataItems = dataItems;
         };
         this._sendWebMessage(messageData);
     }


### PR DESCRIPTION
addressed the backward compatibility issue. For existing plugins, the setup method will be called directly by the constructor while the new plugins will have the option to invoke the setup method explicitly outsite the constructor.