### PR TITLE
Enhancement: Clean sensitive data from logs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ofs-users/plugin",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ofs-users/plugin",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "UPL-1.0",
       "dependencies": {
         "@ofs-users/proxy": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "@ofs-users/plugin",
   "type": "module",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Oracle Field Service plugin base code",
   "main": "dist/ofs-plugin.es.js",
   "module": "dist/ofs-plugin.es.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -197,11 +197,7 @@ export abstract class OFSPlugin {
                         },
                     };
                     console.debug(
-                        `${
-                            this.tag
-                        }. I will request the Token forthe application ${applicationKey} with this message ${JSON.stringify(
-                            callProcedureData
-                        )}`
+                        `${this.tag}. Requesting token for application ${applicationKey}`
                     );
                     this.callProcedure(callProcedureData);
                     globalThis.waitForProxy = true;
@@ -389,11 +385,7 @@ export abstract class OFSPlugin {
                         token: parsed_message.resultData.token,
                     };
                     console.debug(
-                        `${
-                            this.tag
-                        }. I will create the proxy with this data ${JSON.stringify(
-                            OFSCredentials
-                        )}`
+                        `${this.tag}. Creating proxy with provided credentials`
                     );
                     this._proxy = new OFS(OFSCredentials);
                     globalThis.waitForProxy = false;


### PR DESCRIPTION
## Summary
- Remove sensitive credential data from debug logs to prevent accidental exposure
- Sanitize two debug log statements that were logging tokens and credentials via JSON.stringify
- Version bump to 1.5.1

## Changes
- **Token request log** (line 199-201): Removed JSON.stringify of callProcedureData, now logs "Requesting token for application {applicationKey}"
- **Proxy creation log** (line 387-389): Removed JSON.stringify of OFSCredentials (containing baseURL and token), now logs "Creating proxy with provided credentials"

## Benefits
- Improved security posture by preventing credential leaks in logs
- Reduces risk of accidental exposure of API tokens
- Compliance with data protection best practices

## Test Plan
- [ ] Verify application functionality remains unchanged
- [ ] Confirm debug logs no longer expose sensitive credentials
- [ ] Test token request flow
- [ ] Test proxy creation flow

Closes #26