### PR TITLE
30 enhancement add props to close interface

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -67,10 +67,12 @@ export interface OFSCloseData {
     activity?: any;
     backScreen?: BackScreen | string;
     backFormLabel?: string;
+    backPluginLabel?: string;
     backActivityId?: string;
     backInventoryId?: string;
     backResourceId?: string;
     backFormParams?: Record<string, any>;
+    backPluginOpenParams?: Record<string, any>;
     backDraftId?: string;
     backFormSubmitId?: string;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -52,7 +52,8 @@ export enum BackScreen {
     Default = "default",
     OpenForm = "open_form",
     RestoreFormDraft = "restore_form_draft",
-    OpenFormSubmit = "open_form_submit"
+    OpenFormSubmit = "open_form_submit",
+    PluginByLabel = "plugin_by_label"
 }
 
 export enum Procedure {


### PR DESCRIPTION
Did 2 small changes:
1. Added the backPluginLabel and backPluginOpenParams attributes to the OFSCloseData interface, this allows the plugin to open another plugin on close.
2. Added the value "plugin_by_label" to the BackScreen enum to fully support the functionality described on point 1