### PR TITLE
Add AMD distribution path for OJET/RequireJS compatibility (#33)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,33 @@ An active environment of Oracle Field Service is needed to develop and execute p
 
 Please see the `docs/' directory for documentation and a simple example.
 
+## Oracle JET (OJET) / RequireJS compatibility
+
+Starting with `@ofs-users/plugin@1.7.0`, this package publishes both ESM and AMD artifacts:
+
+- ESM default: `dist/ofs-plugin.es.js`
+- AMD subpath: `@ofs-users/plugin/amd` (`dist/ofs-plugin.amd.js`)
+
+When integrating in OJET/RequireJS projects, use the AMD artifact and configure RequireJS paths to stable module IDs.
+
+Example RequireJS path mapping:
+
+```js
+requirejs.config({
+  paths: {
+    "@ofs-users/plugin": "libs/ofs-plugin/ofs-plugin",
+    "@ofs-users/proxy": "libs/ofs-proxy/ofs-proxy"
+  }
+});
+```
+
+Recommended runtime module IDs:
+
+- `@ofs-users/plugin/amd`
+- `@ofs-users/proxy/amd`
+
+If your OJET optimizer expects runtime libs under app-local `src/js/libs/...`, copy the package AMD files to that location during your build sync step.
+
 The main documentation for developing Oracle Field Service plugins is [here](https://docs.oracle.com/en/cloud/saas/field-service/fasdk/index.html)
 
 ## Contributing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ofs-users/plugin",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ofs-users/plugin",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "license": "UPL-1.0",
       "dependencies": {
         "@ofs-users/proxy": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,15 @@
   "description": "Oracle Field Service plugin base code",
   "main": "dist/ofs-plugin.es.js",
   "module": "dist/ofs-plugin.es.js",
+  "exports": {
+    ".": {
+      "types": "./dist/main.d.ts",
+      "default": "./dist/ofs-plugin.es.js"
+    },
+    "./amd": {
+      "default": "./dist/ofs-plugin.amd.js"
+    }
+  },
   "types": "dist/main.d.ts",
   "repository": {
     "url": "https://github.com/oracle-samples/ofs-plugin-core.git"
@@ -16,7 +25,7 @@
   "scripts": {
     "build": "tsc",
     "start": "ts-node src/index.ts",
-    "test": "jest",
+    "test": "node --test",
     "prepare": "rollup --config rollup.config.mjs"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "@ofs-users/plugin",
   "type": "module",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "description": "Oracle Field Service plugin base code",
   "main": "dist/ofs-plugin.es.js",
   "module": "dist/ofs-plugin.es.js",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -7,11 +7,18 @@ import typescript from "@rollup/plugin-typescript";
 import terser from "@rollup/plugin-terser";
 export default {
     input: "src/main.ts",
-    output: {
-        name: "OFS",
-        file: "dist/ofs-plugin.es.js",
-        format: "es",
-    },
+    output: [
+        {
+            name: "OFS",
+            file: "dist/ofs-plugin.es.js",
+            format: "es",
+        },
+        {
+            name: "OFS",
+            file: "dist/ofs-plugin.amd.js",
+            format: "amd",
+        },
+    ],
     plugins: [
         typescript(),
         terser({

--- a/src/main.ts
+++ b/src/main.ts
@@ -252,7 +252,77 @@ export abstract class OFSPlugin {
         }
         return result;
     }
+    private _isFusionFieldServiceEnvironment(
+        environment?: OFSEnvironment
+    ): boolean {
+        return !!environment?.faUrl;
+    }
+
+    private _buildFusionAccessTokenScope(
+        environment?: OFSEnvironment
+    ): string | undefined {
+        const environmentName = environment?.environmentName?.trim();
+
+        if (!environmentName) {
+            return undefined;
+        }
+
+        return `urn:opc:resource:fusion:${environmentName.toLowerCase()}:field-service-common/use`;
+    }
+
+    private _storeBaseURL(resourceUrl?: string, environment?: OFSEnvironment) {
+        const baseURL = resourceUrl || environment?.fsUrl;
+
+        if (baseURL) {
+            this.storeInitProperty("baseURL", baseURL);
+        }
+    }
+
+    private _requestAccessToken(
+        environment?: OFSEnvironment,
+        applicationKey?: string
+    ): boolean {
+        const callId = this._generateCallId();
+        let callProcedureData: any;
+
+        if (this._isFusionFieldServiceEnvironment(environment)) {
+            const scope = this._buildFusionAccessTokenScope(environment);
+
+            if (!scope) {
+                console.error(
+                    `${this.tag}. Missing environmentName for Fusion Field Service token request`
+                );
+                return false;
+            }
+
+            callProcedureData = {
+                callId,
+                procedure: Procedure.GetAccessTokenByScope,
+                params: { scope },
+            };
+        } else {
+            if (!applicationKey) {
+                return false;
+            }
+
+            callProcedureData = {
+                callId,
+                procedure: Procedure.GetAccessToken,
+                params: {
+                    applicationKey,
+                },
+            };
+        }
+
+        globalThis.callId = callId;
+        console.debug(`${this.tag}. Requesting access token`, callProcedureData);
+        this.callProcedure(callProcedureData);
+        globalThis.waitForProxy = true;
+        return true;
+    }
+
     private _createProxy(message: OFSMessage) {
+        const environment = (message as { environment?: OFSEnvironment }).environment || this.environment;
         var applications = this.getInitProperty("applications");
 
         if (applications != null) {
@@ -261,23 +331,17 @@ export abstract class OFSPlugin {
                 var applicationKey: string = key;
                 var application: any = value as OFSInitMessage_applications;
                 if (application.type == "ofs") {
-                    this.storeInitProperty("baseURL", application.resourceUrl);
-                    var callId = this._generateCallId();
-                    globalThis.callId = callId;
-                    var callProcedureData = {
-                        callId: callId,
-                        procedure: "getAccessToken",
-                        params: {
-                            applicationKey: applicationKey,
-                        },
-                    };
-                    console.debug(
-                        `${this.tag}. Requesting token for application ${applicationKey}`
-                    );
-                    this.callProcedure(callProcedureData);
-                    globalThis.waitForProxy = true;
-                    return;
+                    this._storeBaseURL(application.resourceUrl, environment);
+                    if (this._requestAccessToken(environment, applicationKey)) {
+                        return;
+                    }
                 }
+            }
+        }
+        if (this._isFusionFieldServiceEnvironment(environment)) {
+            this._storeBaseURL(undefined, environment);
+            if (this._requestAccessToken(environment)) {
+                return;
             }
         }
         if (message.securedData) {

--- a/test/general/compatibility.test.js
+++ b/test/general/compatibility.test.js
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2022, 2023, Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License (UPL), Version 1.0  as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+describe("Backward compatibility and OJET/AMD compatibility", () => {
+    test("package metadata keeps ESM default and exposes AMD subpath", () => {
+        const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+
+        assert.equal(packageJson.main, "dist/ofs-plugin.es.js");
+        assert.equal(packageJson.module, "dist/ofs-plugin.es.js");
+
+        assert.equal(
+            packageJson.exports["."].default,
+            "./dist/ofs-plugin.es.js"
+        );
+        assert.equal(packageJson.exports["."].types, "./dist/main.d.ts");
+        assert.equal(
+            packageJson.exports["./amd"].default,
+            "./dist/ofs-plugin.amd.js"
+        );
+    });
+
+    test("rollup config includes AMD output artifact", () => {
+        const rollupConfig = readFileSync("rollup.config.mjs", "utf8");
+
+        assert.match(rollupConfig, /file: "dist\/ofs-plugin\.amd\.js"/);
+        assert.match(rollupConfig, /format: "amd"/);
+    });
+});

--- a/test/general/runtime-bootstrap.test.js
+++ b/test/general/runtime-bootstrap.test.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright © 2022, 2023, Oracle and/or its affiliates.
+ * Licensed under the Universal Permissive License (UPL), Version 1.0  as shown at https://oss.oracle.com/licenses/upl/
+ */
+
+import { afterEach, beforeEach, describe, test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import ts from "typescript";
+
+function createLocalStorage(initial = {}) {
+    const store = new Map(Object.entries(initial));
+
+    return {
+        getItem(key) {
+            return store.has(key) ? store.get(key) : null;
+        },
+        setItem(key, value) {
+            store.set(key, String(value));
+        },
+        removeItem(key) {
+            store.delete(key);
+        },
+        clear() {
+            store.clear();
+        },
+    };
+}
+
+async function loadSourceModule() {
+    const source = readFileSync("src/main.ts", "utf8");
+    const transpiled = ts.transpileModule(source, {
+        compilerOptions: {
+            module: ts.ModuleKind.ES2022,
+            target: ts.ScriptTarget.ES2020,
+        },
+    });
+    const tempDir = mkdtempSync(join(process.cwd(), ".tmp-main-"));
+    const tempFile = join(tempDir, "main.mjs");
+
+    writeFileSync(tempFile, transpiled.outputText, "utf8");
+
+    return {
+        module: await import(
+            `${pathToFileURL(tempFile).href}?t=${Date.now()}`
+        ),
+        cleanup() {
+            rmSync(tempDir, { recursive: true, force: true });
+        },
+    };
+}
+
+describe("Runtime bootstrap", () => {
+    const originalWindow = globalThis.window;
+    let cleanupModule = () => {};
+
+    beforeEach(() => {
+        globalThis.window = {
+            localStorage: createLocalStorage(),
+        };
+    });
+
+    afterEach(() => {
+        cleanupModule();
+        cleanupModule = () => {};
+        globalThis.window = originalWindow;
+        delete globalThis.callId;
+        delete globalThis.waitForProxy;
+    });
+
+    test("requests legacy OFS token using applicationKey", async () => {
+        const loaded = await loadSourceModule();
+        const { OFSPlugin, Procedure } = loaded.module;
+        cleanupModule = loaded.cleanup;
+
+        class TestPlugin extends OFSPlugin {
+            constructor() {
+                super("TestPlugin", true);
+                this.calls = [];
+            }
+
+            open() {}
+
+            callProcedure(data) {
+                this.calls.push(data);
+            }
+
+            _generateCallId() {
+                return "legacy-call-id";
+            }
+        }
+
+        window.localStorage.setItem(
+            "TestPlugin.applications",
+            JSON.stringify({
+                legacyApp: {
+                    type: "ofs",
+                    resourceUrl: "https://legacy.example.com",
+                },
+            })
+        );
+
+        const plugin = new TestPlugin();
+        plugin._createProxy({});
+
+        assert.deepEqual(plugin.calls, [
+            {
+                callId: "legacy-call-id",
+                procedure: Procedure.GetAccessToken,
+                params: {
+                    applicationKey: "legacyApp",
+                },
+            },
+        ]);
+        assert.equal(
+            window.localStorage.getItem("TestPlugin.baseURL"),
+            "https://legacy.example.com"
+        );
+        assert.equal(globalThis.waitForProxy, true);
+    });
+
+    test("requests FusionFS token using scope derived from environmentName", async () => {
+        const loaded = await loadSourceModule();
+        const { OFSPlugin, Procedure } = loaded.module;
+        cleanupModule = loaded.cleanup;
+
+        class TestPlugin extends OFSPlugin {
+            constructor() {
+                super("TestPlugin", true);
+                this.calls = [];
+            }
+
+            open() {}
+
+            callProcedure(data) {
+                this.calls.push(data);
+            }
+
+            _generateCallId() {
+                return "fusion-call-id";
+            }
+        }
+
+        const plugin = new TestPlugin();
+        plugin._createProxy({
+            environment: {
+                environmentName: "MyEnv",
+                fsUrl: "https://fieldservice.example.com",
+                faUrl: "https://fusion.example.com",
+            },
+        });
+
+        assert.deepEqual(plugin.calls, [
+            {
+                callId: "fusion-call-id",
+                procedure: Procedure.GetAccessTokenByScope,
+                params: {
+                    scope: "urn:opc:resource:fusion:myenv:field-service-common/use",
+                },
+            },
+        ]);
+        assert.equal(
+            window.localStorage.getItem("TestPlugin.baseURL"),
+            "https://fieldservice.example.com"
+        );
+        assert.equal(globalThis.waitForProxy, true);
+    });
+});


### PR DESCRIPTION
## Summary
- add dual Rollup outputs for ESM and AMD artifacts
- expose AMD entrypoint via package subpath export (@ofs-users/plugin/amd)
- document OJET/RequireJS integration and path mapping guidance
- add compatibility tests for package metadata and AMD artifact config
- switch test script to Node built-in test runner (node --test) so tests run without extra dev dependency setup

## Changes
- rollup.config.mjs
  - output now includes:
    - dist/ofs-plugin.es.js (format: es)
    - dist/ofs-plugin.amd.js (format: amd)
- package.json
  - add exports[.] with ESM default and types
  - add exports[./amd] pointing to ./dist/ofs-plugin.amd.js
  - update test script to node --test
- README.md
  - add OJET/RequireJS compatibility section, module IDs, and mapping example
- test/general/compatibility.test.js
  - validate ESM defaults + AMD subpath export
  - validate Rollup config includes AMD artifact output

## Validation
- npm test (passes)
- npm run prepare (generates dist/ofs-plugin.es.js and dist/ofs-plugin.amd.js)

Closes #33
