### PR TITLE
Support legacy OFS and FusionFS runtime token bootstrap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ofs-users/plugin",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ofs-users/plugin",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "UPL-1.0",
       "dependencies": {
         "@ofs-users/proxy": "^1.9.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   ],
   "name": "@ofs-users/plugin",
   "type": "module",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Oracle Field Service plugin base code",
   "main": "dist/ofs-plugin.es.js",
   "module": "dist/ofs-plugin.es.js",

--- a/src/main.ts
+++ b/src/main.ts
@@ -322,7 +322,17 @@ export abstract class OFSPlugin {
     }
 
     private _createProxy(message: OFSMessage) {
-        const environment = (message as { environment?: OFSEnvironment }).environment || this.environment;
+        const environment =
+            (message as { environment?: OFSEnvironment }).environment ||
+            this.environment;
+
+        if (this._isFusionFieldServiceEnvironment(environment)) {
+            this._storeBaseURL(undefined, environment);
+            if (this._requestAccessToken(environment)) {
+                return;
+            }
+        }
+
         var applications = this.getInitProperty("applications");
 
         if (applications != null) {
@@ -336,12 +346,6 @@ export abstract class OFSPlugin {
                         return;
                     }
                 }
-            }
-        }
-        if (this._isFusionFieldServiceEnvironment(environment)) {
-            this._storeBaseURL(undefined, environment);
-            if (this._requestAccessToken(environment)) {
-                return;
             }
         }
         if (message.securedData) {

--- a/test/general/runtime-bootstrap.test.js
+++ b/test/general/runtime-bootstrap.test.js
@@ -143,6 +143,16 @@ describe("Runtime bootstrap", () => {
             }
         }
 
+        window.localStorage.setItem(
+            "TestPlugin.applications",
+            JSON.stringify({
+                oauth: {
+                    type: "oauth_client_credentials",
+                    resourceUrl: "https://legacy-token-source.example.com/",
+                },
+            })
+        );
+
         const plugin = new TestPlugin();
         plugin._createProxy({
             environment: {
@@ -155,6 +165,63 @@ describe("Runtime bootstrap", () => {
         assert.deepEqual(plugin.calls, [
             {
                 callId: "fusion-call-id",
+                procedure: Procedure.GetAccessTokenByScope,
+                params: {
+                    scope: "urn:opc:resource:fusion:myenv:field-service-common/use",
+                },
+            },
+        ]);
+        assert.equal(
+            window.localStorage.getItem("TestPlugin.baseURL"),
+            "https://fieldservice.example.com"
+        );
+        assert.equal(globalThis.waitForProxy, true);
+    });
+
+    test("prioritizes FusionFS scope bootstrap over legacy application bootstrap", async () => {
+        const loaded = await loadSourceModule();
+        const { OFSPlugin, Procedure } = loaded.module;
+        cleanupModule = loaded.cleanup;
+
+        class TestPlugin extends OFSPlugin {
+            constructor() {
+                super("TestPlugin", true);
+                this.calls = [];
+            }
+
+            open() {}
+
+            callProcedure(data) {
+                this.calls.push(data);
+            }
+
+            _generateCallId() {
+                return "fusion-priority-call-id";
+            }
+        }
+
+        window.localStorage.setItem(
+            "TestPlugin.applications",
+            JSON.stringify({
+                legacyApp: {
+                    type: "ofs",
+                    resourceUrl: "https://legacy.example.com",
+                },
+            })
+        );
+
+        const plugin = new TestPlugin();
+        plugin._createProxy({
+            environment: {
+                environmentName: "MyEnv",
+                fsUrl: "https://fieldservice.example.com",
+                faUrl: "https://fusion.example.com",
+            },
+        });
+
+        assert.deepEqual(plugin.calls, [
+            {
+                callId: "fusion-priority-call-id",
                 procedure: Procedure.GetAccessTokenByScope,
                 params: {
                     scope: "urn:opc:resource:fusion:myenv:field-service-common/use",


### PR DESCRIPTION
## Summary
- detect FusionFS environments via `environment.faUrl`
- use `environment.fsUrl` as the base URL and request the token with `getAccessTokenByScope`
- derive the Fusion scope from `environment.environmentName` as `urn:opc:resource:fusion:<env>:field-service-common/use`
- keep legacy OFS application-based token bootstrap unchanged
- add runtime tests covering FusionFS scope bootstrap precedence and bump the package version to `1.8.0`

## Verification
- `npm test`
- `npm run build`

Closes #35